### PR TITLE
Add basic Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3-alpine
+
+WORKDIR /opt/pterodactyl_exporter/app
+
+RUN mkdir -p /opt/pterodactyl_exporter/config
+
+RUN pip3 install pterodactyl-exporter
+
+# Fixes ModuleNotFoundError, remove after next line after bug has been fixed (see https://github.com/LOENS2/pterodactyl_exporter/issues/4)
+RUN pip3 install prometheus_client
+
+CMD [ "pterodactyl_exporter", "--config-file=/opt/pterodactyl_exporter/config/config.yml" ]
+
+EXPOSE 9531

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  pterodactyl-exporter:
+    # TODO: Change image name once it is released on Docker Hub
+    image: LOENS2/pterodactyl-exporter:latest
+    container_name: pterodactyl-exporter
+    ports:
+      - "9531:9531"
+    volumes:
+      - ../config.yml:/opt/pterodactyl_exporter/config/config.yml


### PR DESCRIPTION
I added a basic Docker image to run the exporter inside Docker.
This would make the setup much easier and more portable, also a lot of folks (myself included) prefer having all their services in containers.