### PR TITLE
Add support for last backup time metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /secret_config.yml
 /secret_config2.yml
 /venv/
+**/*/__pycache__

--- a/pterodactyl_exporter/http_server.py
+++ b/pterodactyl_exporter/http_server.py
@@ -14,6 +14,7 @@ max_swap = Gauge("pterodactyl_server_max_swap_megabytes", "Maximum swap allocate
 max_disk = Gauge("pterodactyl_server_max_disk_megabytes", "Maximum disk space allocated to server in megabytes", label_names)
 io = Gauge("pterodactyl_server_io", "IO weight of server", label_names)
 max_cpu = Gauge("pterodactyl_server_max_cpu_absolute", "Maximum cpu load allowed to server", label_names)
+last_backup_time = Gauge("pterodactyl_server_most_recent_backup_time", "Timestamp of the most recent backup", label_names)
 
 
 def init_metrics():
@@ -35,3 +36,4 @@ def serve_metrics(metrics):
         max_disk.labels(srv_label, id_label).set(metrics["max_disk"][x])
         io.labels(srv_label, id_label).set(metrics["io"][x])
         max_cpu.labels(srv_label, id_label).set(metrics["max_cpu"][x])
+        last_backup_time.labels(srv_label, id_label).set(metrics["last_backup_time"][x])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML~=6.0
 setuptools~=65.3.0
 prometheus-client~=0.14.1
+python-dateutil~=2.8.2


### PR DESCRIPTION
Adds support to pulling out the most recent successful backup time to allow for alerting if there are no recent backups.

Example output:
```
...
# HELP pterodactyl_server_most_recent_backup_time Timestamp of the most recent backup
# TYPE pterodactyl_server_most_recent_backup_time gauge
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 1.667952305e+09
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 1.667952392e+09
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 1.667952339e+09
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 1.668953359e+09
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 0.0
pterodactyl_server_most_recent_backup_time{id="<redacted>",server_name="<redacted>"} 0.0
```