### PR TITLE
rename config file, add vscode debug config and allow server list type to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /secret_config2.yml
 /venv/
 **/*/__pycache__
+/config.yml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "pterodactyl_exporter.pterodactyl_exporter",
+            "justMyCode": true
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ host: panel.example.com
 api_key: APIKEY_APIKEYAPIKEYAPIKEY
 https: true
 ignore_ssl: false
+server_list_type: owner
  ```
 
  - Create systemd service `/etc/systemd/system/pterodactyl_exporter.service`:
@@ -73,7 +74,7 @@ WantedBy=multi-user.target
  
  - Download the config file from GitHub:
  ```
- curl -fsSL -o config.yml https://raw.githubusercontent.com/LOENS2/pterodactyl_exporter/master/config.yml
+ curl -fsSL -o config.yml https://raw.githubusercontent.com/LOENS2/pterodactyl_exporter/master/config.example.yml
  ```
  - Create a folder named `docker`
  
@@ -97,7 +98,7 @@ git clone https://github.com/LOENS2/pterodactyl_exporter.git
  - Change to the cloned directory
  - Run with python:
 ```
-python -m pterodactyl_exporter.pterodactyl_exporter --config-file=config.yml
+python -m pterodactyl_exporter.pterodactyl_exporter --config-file=config.example.yml
 ```
 
 # Troubleshooting

--- a/config.example.yml
+++ b/config.example.yml
@@ -4,4 +4,4 @@ https: true
 ignore_ssl: false
 # Can be set to `admin-all` (return all servers), `owner` (only owned servers)
 # or "" (only accessible servers, shown in your servers list)
-server_list_type: admin-all
+server_list_type: owner

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,7 @@
+host: 
+api_key: 
+https: true
+ignore_ssl: false
+# Can be set to `admin-all` (return all servers), `owner` (only owned servers)
+# or "" (only accessible servers, shown in your servers list)
+server_list_type: admin-all

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,0 @@
-host: 
-api_key: 
-https: true
-ignore_ssl: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /opt/pterodactyl_exporter/app
 
 RUN mkdir -p /opt/pterodactyl_exporter/config
 
-RUN pip3 install pterodactyl-exporter
+COPY . /opt/pterodactyl_exporter/app
 
-CMD [ "pterodactyl_exporter", "--config-file=/opt/pterodactyl_exporter/config/config.yml" ]
+RUN pip3 install -r requirements.txt
 
-EXPOSE 9531
+CMD [ "python3", "-m", "pterodactyl_exporter.pterodactyl_exporter", "--config-file=/opt/pterodactyl_exporter/config/config.yml" ]
+
+EXPOSE 9531/TCP

--- a/pterodactyl_exporter/http_client.py
+++ b/pterodactyl_exporter/http_client.py
@@ -19,7 +19,7 @@ def client_init(config_file: dict):
                "Accept": "Application/vnd.pterodactyl.v1+json"}
 
 
-def get_server():
+def get_server(list_type="owner"):
     global srv
     srv = {
         "name": [],
@@ -37,12 +37,12 @@ def get_server():
         "max_cpu": [],
         "last_backup_time": [],
     }
-    client.request("GET", "/api/client/", "", headers)
+    client.request("GET", "/api/client/?type={}".format(list_type), "", headers)
     servers = json.loads(client.getresponse().read())
     if "errors" in servers:
         print(servers)
         time.sleep(10)
-        get_server()
+        get_server(list_type)
     for x in servers['data']:
         srv["name"].append(x['attributes']['name'])
         srv["id"].append(x['attributes']['identifier'])

--- a/pterodactyl_exporter/pterodactyl_exporter.py
+++ b/pterodactyl_exporter/pterodactyl_exporter.py
@@ -8,7 +8,7 @@ from pterodactyl_exporter import config_load, http_client, http_server
 
 def parse_args():
     parser = argparse.ArgumentParser(description="environment file")
-    parser.add_argument("--config-file")
+    parser.add_argument("--config-file", default="config.yml")
     cfg_file = parser.parse_args().config_file
     if cfg_file is None:
         print("No config provided!")
@@ -26,12 +26,12 @@ def main(args=None):
 
     while True:
         try:
-            http_client.get_server()
+            http_client.get_server(config["server_list_type"])
             metrics = http_client.get_metrics()
             http_server.serve_metrics(metrics)
             time.sleep(10)
         except http.client.RemoteDisconnected:
-            print("API does not respond!")
+            print("API not responding!")
             time.sleep(10)
             continue
 


### PR DESCRIPTION
1. I have renamed the (example) config file so that no one will accidentally commit their config file with secrets to git that easily.
2. adds a VSCode debug config for easy and fast debugging of the exporter in VSCode.
3. If the user can see all the server because they are an admin, the exporter would without this change not pick up any servers. This adds an option to specify the `type` GET parameter that is defined in the API to "filter" the servers returned.

I can remove the config rename and vscode debug config commits if not wanted. I would really like to get the "allow server list type to be set" merged as it as written enables admin users to monitor all servers run by a Pterodactyl instance with ease too.