### PR TITLE
Added the number of online players as a Gauge to display.

### DIFF
--- a/pterodactyl_exporter/http_client.py
+++ b/pterodactyl_exporter/http_client.py
@@ -36,6 +36,7 @@ def get_server(list_type="owner"):
         "io": [],
         "max_cpu": [],
         "last_backup_time": [],
+        "online_players": [],
     }
     client.request("GET", "/api/client/?type={}".format(list_type), "", headers)
     servers = json.loads(client.getresponse().read())

--- a/pterodactyl_exporter/http_client.py
+++ b/pterodactyl_exporter/http_client.py
@@ -68,6 +68,11 @@ def get_metrics():
         srv["rx"].append(metrics["network_rx_bytes"]/1000000)
         srv["tx"].append(metrics["network_tx_bytes"]/1000000)
         srv["uptime"].append(metrics["uptime"])
+        if "online_players" in metrics:
+            srv["online_players"] = metrics["online_players"]
+        else:
+            srv["online_players"] = -1.0
+
 
         get_last_backup_time(x, 1)
 

--- a/pterodactyl_exporter/http_server.py
+++ b/pterodactyl_exporter/http_server.py
@@ -15,6 +15,7 @@ max_disk = Gauge("pterodactyl_server_max_disk_megabytes", "Maximum disk space al
 io = Gauge("pterodactyl_server_io", "IO weight of server", label_names)
 max_cpu = Gauge("pterodactyl_server_max_cpu_absolute", "Maximum cpu load allowed to server", label_names)
 last_backup_time = Gauge("pterodactyl_server_most_recent_backup_time", "Timestamp of the most recent backup", label_names)
+online_players = Gauge("pterodactyl_server_online_players", "Number of players online for the server", label_names)
 
 
 def init_metrics():
@@ -37,3 +38,4 @@ def serve_metrics(metrics):
         io.labels(srv_label, id_label).set(metrics["io"][x])
         max_cpu.labels(srv_label, id_label).set(metrics["max_cpu"][x])
         last_backup_time.labels(srv_label, id_label).set(metrics["last_backup_time"][x])
+        online_players.labels(srv_label, id_label).set(metrics["online_players"])


### PR DESCRIPTION
Added a Gauge for Online Players to be able to track that metric in Prometheus.

The metric will reflect that if the endpoint supports the `online_players` field in the `resources` object of the servers resources endpoint. If there is no field for `online_players` in the `resources` object, the metric will be set to `-1.0`.
